### PR TITLE
Allow more than one file per configuration

### DIFF
--- a/examples/complete_example/.csv_auditor.yml
+++ b/examples/complete_example/.csv_auditor.yml
@@ -1,40 +1,43 @@
 ---
-validations:
-  - name: "exacly_the_same_person"
-    validation: uniqueness
-    columns:
-      - name
-      - email
+- name: "complete validation"
+  file: "examples/complete_example/audit.csv"
+  output: "examples/complete_example/audited.csv"
+  validations:
+    - name: "exacly_the_same_person"
+      validation: uniqueness
+      columns:
+        - name
+        - email
 
-  - name: "duplicated_email"
-    validation: uniqueness
-    columns:
-      - email
+    - name: "duplicated_email"
+      validation: uniqueness
+      columns:
+        - email
 
-  - name: "invalid_email_error"
-    validation: email
-    columns:
-      - email
-    options:
-      strip: true
+    - name: "invalid_email_error"
+      validation: email
+      columns:
+        - email
+      options:
+        strip: true
 
-  - name: "invalid_phone_number_error"
-    validation: format
-    columns:
-      - phone_number
-    options:
-      regex: \d{9}$
+    - name: "invalid_phone_number_error"
+      validation: format
+      columns:
+        - phone_number
+      options:
+        regex: \d{9}$
 
-  - name: "invalid_amount"
-    validation: numericality
-    columns:
-      - amount_usd
-    options:
-      greater_than: 0
+    - name: "invalid_amount"
+      validation: numericality
+      columns:
+        - amount_usd
+      options:
+        greater_than: 0
 
-  - name: "invalid_routing_number"
-    validation: routing_number
-    columns:
-      - routing_number
-    options:
-      padding: true
+    - name: "invalid_routing_number"
+      validation: routing_number
+      columns:
+        - routing_number
+      options:
+        padding: true

--- a/examples/complete_example/audit.csv
+++ b/examples/complete_example/audit.csv
@@ -1,10 +1,10 @@
-name,email,amount_usd,routing_number
-Athena D. Matthews,athena@gmail.com,1000,211371926
-Jason P. Tate,jason@gmail.org,504.69,211371926
-Curtis G. Zook,custis@yahoo.com,504.69,1111
-Mary D. Sanchez,mary@gmail.com,504.69,211371926
-Brent S. Perry,brent@gmail.com,504.69,211371926
-Robert K. Fellows,roberts@gmail.net,504.69,211371926
-Athena D. Matthews,athena@gmail.com,504.69,211371926
-Athena D. Matthews,athena@gmail.com,0,211371926
-Athena D. Matthews,invalid_email@,0,211371926
+name,email,amount_usd,phone_number,routing_number
+Athena D. Matthews,athena@gmail.com,1000,201303303,211371926
+Jason P. Tate,jason@gmail.org,504.69,201303304,211371926
+Curtis G. Zook,custis@yahoo.com,504.69,201303303,1111
+Mary D. Sanchez,mary@gmail.com,504.69,20130330a,211371926
+Brent S. Perry,brent@gmail.com,504.69,201303303,211371926
+Robert K. Fellows,roberts@gmail.net,504.69,201303303,211371926
+Athena D. Matthews,athena@gmail.com,504.69,201303303,211371926
+Athena D. Matthews,athena@gmail.com,0,201303303,211371926
+Athena D. Matthews,invalid_email@,0,201303303,211371926

--- a/examples/complete_example/audited.csv
+++ b/examples/complete_example/audited.csv
@@ -1,10 +1,10 @@
-name,email,amount_usd,routing_number,invalid_routing_number,exacly_the_same_person,duplicated_email,invalid_amount,invalid_email
-Athena D. Matthews,athena@gmail.com,1000,211371926,,,,,
-Jason P. Tate,jason@gmail.org,504.69,211371926,,,,,
-Curtis G. Zook,custis@yahoo.com,504.69,1111,routing_number: 1111 is not a valid routing number,,,,
-Mary D. Sanchez,mary@gmail.com,504.69,211371926,,,,,
-Brent S. Perry,brent@gmail.com,504.69,211371926,,,,,
-Robert K. Fellows,roberts@gmail.net,504.69,211371926,,,,,
-Athena D. Matthews,athena@gmail.com,504.69,211371926,,"name, email: is not unique (duplicate found: row 2)",email: is not unique (duplicate found: row 2),,
-Athena D. Matthews,athena@gmail.com,0,211371926,,"name, email: is not unique (duplicate found: row 2)",email: is not unique (duplicate found: row 2),amount_usd: 0 is not greater than 0,
-Athena D. Matthews,invalid_email@,0,211371926,,,,amount_usd: 0 is not greater than 0,email: invalid_email@ does not match regex 
+name,email,amount_usd,phone_number,routing_number,invalid_routing_number,invalid_phone_number_error,exacly_the_same_person,duplicated_email,invalid_amount,invalid_email_error
+Athena D. Matthews,athena@gmail.com,1000,201303303,211371926,,,,,,
+Jason P. Tate,jason@gmail.org,504.69,201303304,211371926,,,,,,
+Curtis G. Zook,custis@yahoo.com,504.69,201303303,1111,routing_number: 000001111 is not a valid routing number,,,,,
+Mary D. Sanchez,mary@gmail.com,504.69,20130330a,211371926,,phone_number: 20130330a does not match regex \d{9}$,,,,
+Brent S. Perry,brent@gmail.com,504.69,201303303,211371926,,,,,,
+Robert K. Fellows,roberts@gmail.net,504.69,201303303,211371926,,,,,,
+Athena D. Matthews,athena@gmail.com,504.69,201303303,211371926,,,"name, email: is not unique (duplicate found: row 2)",email: is not unique (duplicate found: row 2),,
+Athena D. Matthews,athena@gmail.com,0,201303303,211371926,,,"name, email: is not unique (duplicate found: row 2)",email: is not unique (duplicate found: row 2),amount_usd: 0 is not greater than 0,
+Athena D. Matthews,invalid_email@,0,201303303,211371926,,,,,amount_usd: 0 is not greater than 0,"email: invalid_email@ does not match regex (?-mix:\A[a-zA-Z0-9.!\#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*\z)"

--- a/examples/custom_validator/.csv_auditor.yml
+++ b/examples/custom_validator/.csv_auditor.yml
@@ -1,6 +1,9 @@
 ---
-validations:
-  - name: "cpf"
-    validation: cpf
-    columns:
-      - brcpf
+- name: "custom validation"
+  file: "audit.csv"
+  output: "audited.csv"
+  validations:
+    - name: "cpf_invalid_error"
+      validation: cpf
+      columns:
+        - brcpf

--- a/examples/custom_validator/audited.csv
+++ b/examples/custom_validator/audited.csv
@@ -1,3 +1,3 @@
-name,brcpf,cpf
+name,brcpf,cpf_invalid_error
 Jason P. Tate,01954511040,brcpf: 01954511040 is not a valid CPF
 Ana R.,02945332040,brcpf: 02945332040 is not a valid CPF

--- a/exe/audit
+++ b/exe/audit
@@ -3,29 +3,23 @@
 require "bundler/setup"
 require "csv_auditor"
 
-options = {
-  output: "audited.csv",
-  config: ".csv_auditor.yml"
-}
+options = {}
 
 option_parser = OptionParser.new do |opts|
   opts.banner = "Usage: audit [options]"
 
-  opts.on "-f", "--file file.csv", "File to audit (required)"
-  opts.on "-o", "--output audited.csv", "File to output to (default: audited.csv)"
-  opts.on "-c", "--config .csv_auditor.csv", "Configuration file (default: .csv_auditor.yml)"
+  opts.on "-c", "--config .csv_auditor.csv", "Configuration file path"
 end
 
 option_parser.parse!(into: options)
 
-if options[:file].nil?
+if options[:config].nil?
   puts option_parser.help
   exit 1
 end
 
 CsvAuditor.configure do |config|
-  config.output = options[:output]
   config.config_file_path = options[:config]
 end
 
-CsvAuditor.run(options[:file])
+CsvAuditor.run

--- a/lib/csv_auditor.rb
+++ b/lib/csv_auditor.rb
@@ -9,7 +9,9 @@ require "csv_auditor/configuration"
 require "csv_auditor/runner"
 
 module CsvAuditor
-  def self.run(csv_file)
-    CsvAuditor::Runner.run(csv_file)
+  def self.run
+    CsvAuditor.configuration.executions.each do |execution|
+      CsvAuditor::Runner.run(execution)
+    end
   end
 end

--- a/lib/csv_auditor/configuration.rb
+++ b/lib/csv_auditor/configuration.rb
@@ -15,20 +15,17 @@ module CsvAuditor
   end
 
   class Configuration
-    attr_accessor :config_file_path, :output, :validations, :validators
+    attr_accessor :config_file_path, :output, :executions, :validators
 
-    EXPECTED_COLUMNS = %w[name validation columns].freeze
+    EXPECTED_EXECUTION_COLUMNS = %w[file output validations].freeze
+    EXPECTED_VALIDATION_COLUMNS = %w[name validation columns].freeze
 
     def config_file_path
       @config_file_path ||= ".csv_auditor.yml"
     end
 
-    def output
-      @output ||= "audited.csv"
-    end
-
-    def validations
-      @validations ||= load_validations!
+    def executions
+      @executions ||= load_executions!
     end
 
     def validators
@@ -37,23 +34,32 @@ module CsvAuditor
 
     private
 
-    def load_validations!
-      validations = YAML.load_file(config_file_path)["validations"]
-      validations.each do |validation|
-        EXPECTED_COLUMNS.each do |column|
-          raise "Configuration invalid! Missing #{column}" unless validation[column]
+    def load_executions!
+      executions = YAML.load_file(config_file_path)
+
+      executions.each do |execution|
+        EXPECTED_EXECUTION_COLUMNS.each do |column|
+          raise "Configuration invalid! Missing #{column}" unless execution[column]
+
+          execution["validations"].each do |validation|
+            EXPECTED_VALIDATION_COLUMNS.each do |column|
+              raise "Configuration invalid! Missing #{column}" unless validation[column]
+            end
+          end
         end
       end
 
-      validations
+      executions
     end
 
     def load_validators!
       validators = CsvAuditor::Validator.new
-      validations.each do |validation|
-        loadable_module = validation["validation"]
+      executions.each do |execution|
+        execution["validations"].each do |validation|
+          loadable_module = validation["validation"]
 
-        validators.add(loadable_module) unless validators.validators[loadable_module]
+          validators.add(loadable_module) unless validators.validators[loadable_module]
+        end
       end
 
       validators


### PR DESCRIPTION
This allows to specify more than one file per configuration. 

```yaml
---
- name: "simple validation"
  file: "examples/complete_example/audit.csv"
  output: "examples/complete_example/audited.csv"
  validations:
    - name: "exacly_the_same_person"
      validation: uniqueness
      columns:
        - name
        - email


```